### PR TITLE
Defining jquery-ui as dependency instead of jquery.ui

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -19,7 +19,7 @@
     if ( typeof define === "function" && define.amd ) {
 
         // AMD. Register as an anonymous module.
-        define([ "jquery", "jquery.ui" ], factory );
+        define([ "jquery", "jquery-ui" ], factory );
     } else {
 
         // Browser globals


### PR DESCRIPTION
In the AMD definition the 'jquery.ui' dependency seem to be invalid. Building a project with webpack results in this error:

> ERROR  Failed to compile with 1 errors
>
> This dependency was not found:
>
> * jquery.ui in ./node_modules/@rwap/jquery-ui-touch-punch/jquery.ui.touch-punch.js

Using 'jquery-ui' instead of 'jquery.ui' fixes that.