### PR TITLE
Replace deprecated $.fn.bind/unbind

### DIFF
--- a/jquery.ui.touch-punch.js
+++ b/jquery.ui.touch-punch.js
@@ -194,6 +194,10 @@
     touchHandled = false;
   };
 
+  let _touchStartBound = mouseProto._touchStart.bind(mouseProto),
+      _touchMoveBound = mouseProto._touchMove.bind(mouseProto),
+      _touchEndBound = mouseProto._touchEndBound.bind(mouseProto);
+
   /**
    * A duck punch of the $.ui.mouse _mouseInit method to support touch events.
    * This method extends the widget with bound touch event handlers that
@@ -210,11 +214,11 @@
     }	  
 
     // Delegate the touch handlers to the widget's element
-    self.element.bind(
-      {'touchstart': mouseProto._touchStart},
-      {'touchmove': mouseProto._touchMove},
-      {'touchend': mouseProto._touchEnd}
-    );
+    self.element.on({
+      touchstart: _touchStartBound,
+      touchmove: _touchMoveBound,
+      touchend: _touchEndBound
+    });
 
     // Call the original $.ui.mouse init method
     _mouseInit.call(self);
@@ -228,11 +232,11 @@
     let self = this;
 
     // Delegate the touch handlers to the widget's element
-    self.element.unbind(
-      {'touchstart': mouseProto._touchStart},
-      {'touchmove': mouseProto._touchMove},
-      {'touchend': mouseProto._touchEnd}
-    );
+    self.element.off({
+      touchstart: _touchStartBound,
+      touchmove: _touchMoveBound,
+      touchend: _touchEndBound
+    });
 
     // Call the original $.ui.mouse destroy method
     _mouseDestroy.call(self);


### PR DESCRIPTION
Related:
https://github.com/RWAP/jquery-ui-touch-punch/commit/f84778610abd5489ceed0618fa82e273341e5371
https://github.com/RWAP/jquery-ui-touch-punch/issues/27

When the deprecated `$.proxy` was replaced, the deprecated `$.fn.bind` and `$.fn.unbind` were used instead of changing only the use of proxy to the native function bind method.

This PR corrects this and adds the intended changes.